### PR TITLE
Got rid of qw(:all)

### DIFF
--- a/lib/Net/OpenSSH/Parallel/Constants.pm
+++ b/lib/Net/OpenSSH/Parallel/Constants.pm
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 use Carp;
 
-use Net::OpenSSH::Constants qw(:all);
+use Net::OpenSSH::Constants;
 
 require Exporter;
 our @ISA = qw(Exporter);


### PR DESCRIPTION
to avoid '"all" is not defined in %Net::OpenSSH::Constants::EXPORT_TAGS'
